### PR TITLE
HEOS mix

### DIFF
--- a/PDSim/core/core.py
+++ b/PDSim/core/core.py
@@ -1251,7 +1251,7 @@ class PDSimCore(object):
 
                 if len(self.solvers.hdisc_history) == 1:
                     # The first time we get here, perturb the discharge enthalpy
-                    self.Tubes.Nodes[self.key_outlet].update_ph(self.Tubes.Nodes[self.key_outlet].p, h_outlet + 5)
+                    h_target = h_outlet + 5
                 else:
                     #  Get the values from the history
                     hdn1, EBn1 = self.solvers.hdisc_history[-1]
@@ -1262,7 +1262,13 @@ class PDSimCore(object):
                     
                     #  Reset the outlet enthalpy of the outlet tube based on our new
                     #  value for it
-                    self.Tubes.Nodes[self.key_outlet].update_ph(self.Tubes.Nodes[self.key_outlet].p, hdnew)
+                    h_target = hdnew
+                    
+                # Iterate to solve the H, P flash calculation
+                def objective(T):
+                    self.Tubes.Nodes[self.key_outlet].update(dict(T=T, P=self.Tubes.Nodes[self.key_outlet].p))
+                    return self.Tubes.Nodes[self.key_outlet].h - h_target
+                scipy.optimize.newton(objective, self.Tubes.Nodes[self.key_outlet].T)
 
                 print(self.solvers.hdisc_history)
                 

--- a/PDSim/core/core.py
+++ b/PDSim/core/core.py
@@ -784,7 +784,11 @@ class PDSimCore(object):
         # for some conditions and you are better off just calculating the enthalpy
         # directly
         temp = outletState.copy()
-        temp.update(dict(P=outletState.p, S=s1))
+        def objective(T):
+            temp.update(dict(P=outletState.p, T=T))
+            return temp.s - s1
+        scipy.optimize.newton(objective, outletState.T)
+            
         h2s = temp.h
         
         if outletState.p > inletState.p:

--- a/PDSim/flow/flow_models.pyx
+++ b/PDSim/flow/flow_models.pyx
@@ -290,9 +290,9 @@ cpdef IsothermalWallTube(mdot,State1,State2,fixed,L,ID,OD=None,HTModel='Twall',T
                     r = State2.h - h2
                     rprime = State2.pAS.first_partial_deriv(constants_header.iHmass, constants_header.iT, constants_header.iP)/1000 # AbstractState has enthalpy in kJ/kg
                     dT = -r/rprime
-                        T += dT
-                        if abs(r) < 0.02:
-                            break
+                    T += dT
+                    if abs(r) < 0.02:
+                        break
                 else :
                     raise ValueError("unclear what to do here")
             

--- a/PDSim/flow/flow_models.pyx
+++ b/PDSim/flow/flow_models.pyx
@@ -281,7 +281,7 @@ cpdef IsothermalWallTube(mdot,State1,State2,fixed,L,ID,OD=None,HTModel='Twall',T
                 # so a local Newton's method approach is used instead
                 # and we cannot use scipy.optimize.newton because Cython
                 # does not support closures in cpdef functions.
-                if hasattr(State2,'pAS') and State2.pAS.fluid_names() > 1:
+                if hasattr(State2,'pAS') and len(State2.pAS.fluid_names()) > 1:
                     # Use Newton's method to solve for the 
                     # temperature yielding the outlet enthalpy
                     T = T2_star

--- a/PDSim/flow/flow_models.pyx
+++ b/PDSim/flow/flow_models.pyx
@@ -285,14 +285,14 @@ cpdef IsothermalWallTube(mdot,State1,State2,fixed,L,ID,OD=None,HTModel='Twall',T
                     # Use Newton's method to solve for the 
                     # temperature yielding the outlet enthalpy
                     T = T2_star
-					for counter in range(30):
-						State2.update(dict(T=T, P=p+DELTAP/1000))
-						r = State2.h - h2
-						rprime = State2.pAS.first_partial_deriv(constants_header.iHmass, constants_header.iT, constants_header.iP)/1000 # AbstractState has enthalpy in kJ/kg
-						dT = -r/rprime
-						T += dT
-						if abs(r) < 0.02:
-							break
+                    for counter in range(30):
+                        State2.update(dict(T=T, P=p+DELTAP/1000))
+                        r = State2.h - h2
+                        rprime = State2.pAS.first_partial_deriv(constants_header.iHmass, constants_header.iT, constants_header.iP)/1000 # AbstractState has enthalpy in kJ/kg
+                        dT = -r/rprime
+                        T += dT
+                        if abs(r) < 0.02:
+                            break
                 else :
                     raise ValueError("unclear what to do here")
             

--- a/PDSim/flow/flow_models.pyx
+++ b/PDSim/flow/flow_models.pyx
@@ -285,14 +285,14 @@ cpdef IsothermalWallTube(mdot,State1,State2,fixed,L,ID,OD=None,HTModel='Twall',T
                     # Use Newton's method to solve for the 
                     # temperature yielding the outlet enthalpy
                     T = T2_star
-                for counter in range(30):
-                    State2.update(dict(T=T, P=p+DELTAP/1000))
-                    r = State2.h - h2
-                    rprime = State2.pAS.first_partial_deriv(constants_header.iHmass, constants_header.iT, constants_header.iP)/1000 # AbstractState has enthalpy in kJ/kg
-                    dT = -r/rprime
-                    T += dT
-                    if abs(r) < 0.02:
-                        break
+					for counter in range(30):
+						State2.update(dict(T=T, P=p+DELTAP/1000))
+						r = State2.h - h2
+						rprime = State2.pAS.first_partial_deriv(constants_header.iHmass, constants_header.iT, constants_header.iP)/1000 # AbstractState has enthalpy in kJ/kg
+						dT = -r/rprime
+						T += dT
+						if abs(r) < 0.02:
+							break
                 else :
                     raise ValueError("unclear what to do here")
             

--- a/PDSim/scroll/core.py
+++ b/PDSim/scroll/core.py
@@ -950,7 +950,8 @@ class Scroll(PDSimCore, _Scroll):
                 #It is the outermost pair of compression chambers
                 initState = State.State(inletState.Fluid,
                                         dict(T=inletState.T,
-                                             D=inletState.rho)
+                                             D=inletState.rho), 
+                                        phase='gas'
                                         )
                 
             else:

--- a/PDSim/scroll/core.py
+++ b/PDSim/scroll/core.py
@@ -18,6 +18,7 @@ from CoolProp import State
 from math import pi, exp
 import numpy as np
 import copy
+import scipy.optimize
 
 # If scipy is available, use its interpolation and optimization functions, otherwise, 
 # use our implementation (for packaging purposes mostly)

--- a/PDSim/scroll/core.py
+++ b/PDSim/scroll/core.py
@@ -1866,17 +1866,35 @@ class Scroll(PDSimCore, _Scroll):
                 
         inletState = self.Tubes.Nodes[self.key_inlet]
         outletState = self.Tubes.Nodes[self.key_outlet]
-        s1 = inletState.s
-        h1 = inletState.h
-        temp = inletState.copy()
-        temp.update(dict(S = s1, P = outletState.p))
-        h2s = temp.h
         
+        h1 = inletState.h
+        s1 = inletState.s
+        outletState = inletState.copy()
+        
+        # For an adiabatic process in which the ratio of heat capacities 
+        # gamma is approximately constant, you can calculate the 
+        # relation between T and p along the isentropic path from:
+        # p1^(1-gamma)*T1^gamma = p2^(1-gamma)*T2^gamma
+        
+        # See: https://en.wikipedia.org/wiki/Table_of_thermodynamic_equations#Thermodynamic_processes
+        gamma = inletState.cp/inletState.cv
+        T2s = (inletState.p**(1-gamma)*inletState.T**gamma/outletState.p**(1-gamma))**(1/gamma)
+        
+        # Solver to correct for non-constant gamma to get isentropic enthalpy h2s, 
+        # should be a small correction
+        def objective_h2s(T):
+            outletState.update(dict(T=T, P=outletState.p))
+            return outletState.s - s1
+        T2s = scipy.optimize.newton(objective_h2s, T2s)
+        h2s = outletState.h
+        
+        # And now we iterate to get the given efficiency
+        h1 = inletState.h
         if outletState.p > inletState.p:
-            #Compressor Mode
+            # Compressor Mode
             h2 = h1 + (h2s-h1)/eta_a
         else:
-            #Expander Mode
+            # Expander Mode
             h2 = h1 + (h2s-h1)*eta_a
         
         # A guess for the compressor mechanical power based on 70% efficiency [kW]

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -12,5 +12,5 @@ dependencies:
   - pip
   - pip:
     - CoolProp
-    - Cython
+    - Cython<3
     - quantities

--- a/examples/scroll_compressor.py
+++ b/examples/scroll_compressor.py
@@ -68,14 +68,14 @@ def Compressor(ScrollClass, Te = 273, Tc = 300, f = None, OneCycle = False, Ref 
     Te = -20 + 273.15
     Tc = 20 + 273.15
     Tin = Te + 11.1
-    temp = State.State(Ref,{'T':Te,'Q':1})
+    temp = State.State(Ref,{'T':Te,'Q':1}, phase='gas')
     pe = temp.p
     temp.update(dict(T=Tc, Q=1))
     pc = temp.p
-    inletState = State.State(Ref,{'T':Tin,'P':pe})
+    inletState = State.State(Ref,{'T':Tin,'P':pe}, phase='gas')
 
-    T2s = ScrollComp.guess_outlet_temp(inletState,pc)
-    outletState = State.State(Ref,{'T':T2s,'P':pc})
+    T2s = ScrollComp.guess_outlet_temp(inletState, pc)
+    outletState = State.State(Ref,{'T':T2s,'P':pc}, phase='gas')
     
     mdot_guess = inletState.rho*ScrollComp.Vdisp*ScrollComp.omega/(2*pi)
     

--- a/examples/scroll_compressor_bicubic_with_mixtures.py
+++ b/examples/scroll_compressor_bicubic_with_mixtures.py
@@ -1,15 +1,21 @@
-from __future__ import print_function
+import os 
 
 from PDSim.scroll.core import Scroll
 from scroll_compressor import Compressor
 
-# from CoolProp import CoolProp as CP
-# CP.set_config_string(CP.ALTERNATIVE_REFPROP_PATH, r'/home/ian/REFPROP911')
+from CoolProp import CoolProp as CP
+CP.set_config_string(CP.ALTERNATIVE_REFPROP_PATH, os.getenv('RPPREFIX'))
 
 # CP.set_debug_level(1)
 
-# Use this one to use R410A as a mixture
-Compressor(Scroll, Ref='BICUBIC&REFPROP::R32[0.697614699375863]&R125[0.302385300624138]')
+# Use this one to use R410A as a pseudo-pure fluid
+Compressor(Scroll, Ref='R410A', HDF5file='R410APPF.h5')
 
-# Use this one to use R410A as a pure fluid
-#Compressor(Ref='R410A')
+# Use this one to use R410A as a mixture w/ REFPROP
+Compressor(Scroll, Ref='REFPROP::R32[0.697614699375863]&R125[0.302385300624138]', HDF5file='REFPROPR410Amix.h5')
+
+# Use this one to use R410A as a mixture w/ REFPROP and bicubic interpolation
+Compressor(Scroll, Ref='BICUBIC&REFPROP::R32[0.697614699375863]&R125[0.302385300624138]', HDF5file='REFPROPBICUBICR410Amix.h5')
+
+# Use this one to use R410A as a mixture w/ the HEOS backend of CoolProp
+Compressor(Scroll, Ref='HEOS::R32[0.697614699375863]&R125[0.302385300624138]', HDF5file='HEOSR410Amix.h5')


### PR DESCRIPTION
Fix the code in PDSim to allow for the use of multicomponent mixtures with the HEOS backend of CoolProp.  The primary change is to convert all P,H and P,S flash calls to instead use newton iterations in PDSim rather than delegating those calls to CoolProp.