### PR TITLE
Update conda_environment.yml

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - matplotlib
   - pyyaml
   - h5py
+  - xlsxwriter
   - wxpython
   - pandas
   - pip


### PR DESCRIPTION
Could add 'xlsxwriter' in the file "conda_environment.yml" to solve the issue when output h5 file into excel file with PDSim GUI:

ModuleNotFoundError: No module named 'xlsxwriter'