### PR TITLE
Guard against CoolProp enum-renumbering ABI mismatch at import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ PDSim/flow/flow.html
 PDSim/flow/flow_models.cpp
 PDSim/flow/flow_models.h
 PDSim/flow/flow_models.html
+PDSim/misc/_coolprop_abi.cpp
+PDSim/misc/_coolprop_abi.html
 PDSim/misc/clipper/pyclipper.cpp
 PDSim/misc/clipper/pyclipper.html
 PDSim/misc/datatypes.cpp

--- a/PDSim/__init__.py
+++ b/PDSim/__init__.py
@@ -1,3 +1,7 @@
 __version__ = "2.15"
-__git_revision__ = '9b80be9a66f31ea61a9b92865f779fd5d75ab7e5'
+__git_revision__ = 'bdb3f251695a1cf43bac32cfc6e5df7ed5326650'
 __git_branch__ = 'master'
+
+from PDSim._abi_check import check_coolprop_abi as _check_coolprop_abi
+_check_coolprop_abi()
+del _check_coolprop_abi

--- a/PDSim/_abi_check.py
+++ b/PDSim/_abi_check.py
@@ -1,0 +1,89 @@
+"""
+Import-time guard that PDSim's compiled extensions match the installed CoolProp.
+
+CoolProp renumbers its property/input enums between releases.  Because PDSim's
+Cython code compiles those enum members to integer literals, a PDSim binary
+built against one CoolProp silently reads the wrong properties from another --
+see ``PDSim/misc/_coolprop_abi.pyx`` for the full explanation.
+
+This module compares the enum values frozen into the binary at build time
+against the values reported by the *installed* CoolProp, and raises a clear,
+actionable error at ``import PDSim`` instead of letting the mismatch surface as
+a cryptic ``ValueError: p is not a valid number`` deep inside ``solve()``.
+"""
+from __future__ import absolute_import
+
+
+class CoolPropABIMismatch(ImportError):
+    """PDSim's compiled CoolProp enum values disagree with the installed
+    CoolProp -- PDSim must be rebuilt against the installed CoolProp."""
+    pass
+
+
+def _format_message(mismatches, version):
+    lines = [
+        "PDSim was compiled against a different CoolProp than the one "
+        "installed (CoolProp {0}).".format(version),
+        "",
+        "CoolProp renumbers its property/input enums between releases, and "
+        "PDSim bakes those numbers into its compiled extensions, so a PDSim "
+        "binary built against one CoolProp reads the wrong properties from "
+        "another -- typically surfacing much later as a cryptic "
+        "'ValueError: p is not a valid number' inside solve().",
+        "",
+        "Mismatched enum values (name: built -> installed):",
+    ]
+    for name in sorted(mismatches):
+        built, installed = mismatches[name]
+        shown = 'MISSING' if installed is None else installed
+        lines.append("    {0}: {1} -> {2}".format(name, built, shown))
+    lines += [
+        "",
+        "Resolution -- rebuild PDSim against the installed CoolProp:",
+        "  * from a source checkout (rebuild the in-place extensions):",
+        "        python setup.py build_ext --inplace --force",
+        "  * installed with pip (force a fresh compile, no cached wheel):",
+        "        pip install --force-reinstall --no-binary PDSim PDSim",
+        "  * with uv (a plain `uv sync` reuses uv's cached build -- bust it):",
+        "        uv cache clean pdsim && uv sync",
+    ]
+    return "\n".join(lines)
+
+
+def check_coolprop_abi(raise_on_mismatch=True):
+    """Compare the CoolProp enum values baked into PDSim against the installed
+    CoolProp.
+
+    Returns a dict ``{name: (built_value, installed_value)}`` of any mismatches
+    (empty if all agree).  When ``raise_on_mismatch`` is true (the default), a
+    non-empty result raises :class:`CoolPropABIMismatch` with rebuild
+    instructions.
+
+    Returns ``{}`` without raising if either the compiled fingerprint module or
+    CoolProp cannot be imported -- there is then nothing to compare and the
+    real import error will surface on its own.
+    """
+    try:
+        from PDSim.misc._coolprop_abi import build_abi_fingerprint
+    except Exception:
+        return {}
+    try:
+        import CoolProp
+        from CoolProp import constants
+    except Exception:
+        return {}
+
+    built = build_abi_fingerprint()
+    mismatches = {}
+    for name, built_value in built.items():
+        installed_value = getattr(constants, name, None)
+        if installed_value is None:
+            mismatches[name] = (built_value, None)
+        elif int(installed_value) != int(built_value):
+            mismatches[name] = (built_value, int(installed_value))
+
+    if mismatches and raise_on_mismatch:
+        version = getattr(CoolProp, '__version__', 'unknown')
+        raise CoolPropABIMismatch(_format_message(mismatches, version))
+
+    return mismatches

--- a/PDSim/misc/_coolprop_abi.pyx
+++ b/PDSim/misc/_coolprop_abi.pyx
@@ -1,0 +1,53 @@
+# cython: language_level=3
+"""
+Build-time fingerprint of the CoolProp enum values that PDSim bakes in.
+
+PDSim's compiled extensions ``cimport CoolProp.constants_header`` and use
+members such as ``constants.iDmass`` to read fluid properties.  Cython compiles
+those enum members to *bare integer literals* in the generated C, so the
+numbers are frozen at PDSim build time.
+
+CoolProp renumbers its ``parameters`` / ``input_pairs`` enums between releases
+(e.g. ``iDmass`` was 36 in 7.1.0 and 39 in 7.2.0; more move again in 8.x).
+Nothing in the binary records which numbering it was built with -- the
+``State`` C struct is unchanged, so Cython's own cross-module size/checksum
+import check passes silently.  A PDSim binary built against one CoolProp then
+asks a different runtime CoolProp for the wrong parameter, returning a garbage
+density that only blows up much later as a cryptic
+``ValueError: p is not a valid number`` deep inside ``solve()``.
+
+The values captured here are whatever this binary was compiled against.  At
+import, :func:`PDSim._abi_check.check_coolprop_abi` compares them against the
+*installed* CoolProp (read from its pure-Python ``constants`` module) and fails
+fast with rebuild instructions if they disagree.
+
+Only the constants PDSim actually uses as values are tracked -- see the
+``constants.*`` / ``constants_header.*`` usages in containers.pyx,
+state_flooded.pyx and flow_models.pyx.
+"""
+cimport CoolProp.constants_header as ch
+
+
+cpdef dict build_abi_fingerprint():
+    """The CoolProp enum integer values this PDSim binary was compiled against."""
+    return {
+        # parameters enum (property output keys)
+        'iT': <long>ch.iT,
+        'iP': <long>ch.iP,
+        'iQ': <long>ch.iQ,
+        'iDmass': <long>ch.iDmass,
+        'iHmass': <long>ch.iHmass,
+        'iSmass': <long>ch.iSmass,
+        'iUmass': <long>ch.iUmass,
+        'iCpmass': <long>ch.iCpmass,
+        'iCp0mass': <long>ch.iCp0mass,
+        'iCvmass': <long>ch.iCvmass,
+        'imolar_mass': <long>ch.imolar_mass,
+        'iviscosity': <long>ch.iviscosity,
+        'iconductivity': <long>ch.iconductivity,
+        'ispeed_sound': <long>ch.ispeed_sound,
+        'iT_critical': <long>ch.iT_critical,
+        'iP_critical': <long>ch.iP_critical,
+        # input_pairs enum (update() input specifiers)
+        'PT_INPUTS': <long>ch.PT_INPUTS,
+    }

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,13 @@ lines = []
 lines.append(f'__version__ = "{version}"')
 lines.append("__git_revision__ = '" + git_hash + "'")
 lines.append("__git_branch__ = '" + git_branch + "'")
+# Verify at import that the compiled extensions match the installed CoolProp
+# enum ABI (see PDSim/misc/_coolprop_abi.pyx); raises with rebuild instructions
+# on a mismatch instead of failing cryptically deep inside solve().
+lines.append("")
+lines.append("from PDSim._abi_check import check_coolprop_abi as _check_coolprop_abi")
+lines.append("_check_coolprop_abi()")
+lines.append("del _check_coolprop_abi")
 with open(fName,'w') as fp:
     fp.write('\n'.join(lines)+'\n')
 print('to be written to __init__.py:')
@@ -68,6 +75,7 @@ import numpy
 
 # Each of the Pure-Python or PYX files in this list will be compiled to a python module       
 pyx_list = [
+            "PDSim/misc/_coolprop_abi.pyx",
             "PDSim/core/_bearings.pyx",
             "PDSim/core/containers.pyx",
             "PDSim/core/callbacks.pyx",

--- a/test/test_abi_check.py
+++ b/test/test_abi_check.py
@@ -1,0 +1,40 @@
+"""Tests for the CoolProp ABI guard (PDSim/_abi_check.py)."""
+import pytest
+
+from PDSim._abi_check import check_coolprop_abi, CoolPropABIMismatch
+from PDSim.misc import _coolprop_abi
+
+
+def test_matching_abi_does_not_raise():
+    """The binary we are running was built against the installed CoolProp, so
+    the real check must find no mismatches."""
+    assert check_coolprop_abi() == {}
+
+
+def test_renumbered_enum_is_detected(monkeypatch):
+    """If a baked-in enum value disagrees with the installed CoolProp, the
+    guard reports it and raises with rebuild advice."""
+    real = _coolprop_abi.build_abi_fingerprint()
+    # Simulate a binary built against an older CoolProp where iDmass was 36.
+    tampered = dict(real, iDmass=real['iDmass'] + 9999)
+    monkeypatch.setattr(_coolprop_abi, 'build_abi_fingerprint', lambda: tampered)
+
+    mismatches = check_coolprop_abi(raise_on_mismatch=False)
+    assert 'iDmass' in mismatches
+    assert mismatches['iDmass'][0] == tampered['iDmass']
+
+    with pytest.raises(CoolPropABIMismatch) as exc:
+        check_coolprop_abi()
+    msg = str(exc.value)
+    assert 'iDmass' in msg
+    assert 'build_ext --inplace' in msg
+
+
+def test_missing_constant_is_detected(monkeypatch):
+    """A constant that no longer exists in the installed CoolProp is flagged."""
+    real = _coolprop_abi.build_abi_fingerprint()
+    tampered = dict(real, iNonexistentParameter=12345)
+    monkeypatch.setattr(_coolprop_abi, 'build_abi_fingerprint', lambda: tampered)
+
+    mismatches = check_coolprop_abi(raise_on_mismatch=False)
+    assert mismatches.get('iNonexistentParameter') == (12345, None)


### PR DESCRIPTION
## Problem

`examples/simple_example.py` (and PDSim generally) fails with CoolProp 7.2 but works with 7.1, surfacing as a cryptic `ValueError: p is not a valid number` deep inside `solve()`.

**Root cause:** CoolProp renumbers its `parameters`/`input_pairs` enums between releases — `iDmass` moved 36→39, `iHmass` 37→40, and ~8 more from 7.1.0 to 7.2.0 (more change in 8.x). PDSim's Cython extensions use these members (`constants.iDmass`, …), which Cython compiles to **bare integer literals frozen into the `.so` at build time**. The CoolProp `State` C struct is *unchanged* across these releases, so Cython's own cross-module size/checksum import check passes silently. A PDSim binary built against one CoolProp then asks a different runtime CoolProp for the wrong parameter → garbage density → blows up much later in `solve()`.

The fix for the failure itself is simply to rebuild PDSim against the installed CoolProp (`python setup.py build_ext --inplace --force`). This PR adds a guard so the mismatch is caught immediately and clearly instead of failing cryptically.

## What this adds

An import-time check that compares the enum values baked into the binary against the installed CoolProp:

| File | Change |
|---|---|
| `PDSim/misc/_coolprop_abi.pyx` | Compiled module freezing the build-time values of the 17 CoolProp enums PDSim uses |
| `PDSim/_abi_check.py` | `check_coolprop_abi()` diffs baked vs. installed values; raises `CoolPropABIMismatch` with rebuild advice; degrades silently if either side can't be imported |
| `PDSim/__init__.py`, `setup.py` | Run the check on `import PDSim` (and emit the call into the generated `__init__.py`) |
| `test/test_abi_check.py` | match passes; renumbered enum raises; missing constant detected |
| `.gitignore` | Ignore the new module's generated `.cpp`/`.html` |

On a mismatch, `import PDSim` now raises:

```
CoolPropABIMismatch: PDSim was compiled against a different CoolProp than the one installed (CoolProp 7.2.0).
...
Mismatched enum values (name: built -> installed):
    iDmass: 36 -> 39
    iHmass: 37 -> 40
    ...
Resolution -- rebuild PDSim against the installed CoolProp:
  * python setup.py build_ext --inplace --force
  * pip install --force-reinstall --no-binary PDSim PDSim
  * uv cache clean pdsim && uv sync
```

The check compares actual enum values, not a version string, so it also catches the upcoming 8.x renumbering for any constant PDSim uses.

## Validation

In an isolated worktree: built against 7.1.0 → guard passes, 3 unit tests green; swapped in 7.2.0 without rebuild → guard raises listing all 10 shifted enums; rebuilt against 7.2.0 → guard clears (`mismatches: {}`).

## Notes / follow-up

This *detects* the mismatch. A follow-up could *eliminate* it by resolving enum values from the installed CoolProp at runtime instead of baking literals, so no rebuild is ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)