### PR TITLE
Fix two example script bugs (default_timer typo; unguarded debug_plots)

### DIFF
--- a/examples/scroll_compressor_multilump.py
+++ b/examples/scroll_compressor_multilump.py
@@ -191,7 +191,7 @@ def Compressor(Te = 0,DTsh = 11.1,Tc = 20, Tamb = 25, Nmot = 3600, f = None, One
                                  lumps_energy_balance_callback = ScrollComp.lump_energy_balance_callback
                                  )
 
-    t1=default_timer()
+    t1=timeit.default_timer()
     ScrollComp.RK45_eps = 1e-6
     ScrollComp.eps_cycle = 3e-3
     ScrollComp.verbosity = 10
@@ -207,7 +207,7 @@ def Compressor(Te = 0,DTsh = 11.1,Tc = 20, Tamb = 25, Nmot = 3600, f = None, One
                         eps_energy_balance = 0.1 #relaxed multi-lump convergence
                         )
 
-    print('time taken', default_timer()-t1)
+    print('time taken', timeit.default_timer()-t1)
 
     if '--plot' in sys.argv:
         debug_plots(ScrollComp)

--- a/examples/scroll_compressor_valves.py
+++ b/examples/scroll_compressor_valves.py
@@ -242,8 +242,9 @@ def Compressor(ScrollClass, Te = 253, Tc = 310, f = None, OneCycle = False, Ref 
     h5 = HDF5Writer()
     h5.write_to_file(ScrollComp, HDF5file)
 
-    debug_plots(ScrollComp, family='Scroll Compressor')
-    
+    if plotting:
+        debug_plots(ScrollComp, family='Scroll Compressor')
+
     return ScrollComp
     
 if __name__=='__main__':


### PR DESCRIPTION
## What

Two small, physics-independent bug fixes to example scripts, found while running all examples against the CoolProp v8 beta from test.pypi. Neither is CoolProp-specific — they would fail the same way on any version.

### `examples/scroll_compressor_multilump.py`
Called the undefined bare name `default_timer()` (raising `NameError` *before* the solve even started). Changed to `timeit.default_timer()` — `timeit` is already imported, and this matches `simple_example.py` / `scroll_compressor.py`.

### `examples/scroll_compressor_valves.py`
The final `debug_plots(ScrollComp, ...)` call was unconditional, so it raised `NameError: name 'debug_plots' is not defined` whenever `wxPython` isn't installed (the import is gated behind a `try/except` that sets a `plotting` flag). The simulation itself ran to completion; only the trailing plot call failed. Guarded it with `if plotting:`, matching the idiom in `recip_compressor.py`.

## Verification

Both run under the CoolProp v8 beta (`7.2.1.dev20260610124924`):
- `scroll_compressor_valves.py` → completes cleanly (rc=0): VE 91.85%, AE 65.6%.
- `scroll_compressor_multilump.py` → gets past the `NameError` into the solver.

## Note (out of scope)

With the typo fixed, `scroll_compressor_multilump.py` now surfaces a separate, pre-existing geometry precision bug in `PDSim/scroll/symm_scroll_geo.pyx:515` (`_radial_leakage_angles`): `phi_max(15.148966328953213) < phi_min(15.148966328953215)`, a ~2-ULP ordering failure. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)