### PR TITLE
perf(scroll): scalar cross-product + lazy nozzle outputs (bit-identical, ~8%)

### DIFF
--- a/PDSim/flow/flow_models.pyx
+++ b/PDSim/flow/flow_models.pyx
@@ -624,16 +624,27 @@ cpdef double IsentropicNozzle(double A, State State_up, State State_down, int ot
     T_up=State_up.get_T()
     p_down=State_down.get_p()
     
-    # Speed of sound
-    c=(k*R*T_up)**0.5
     # Upstream density
     rho_up=p_up*1000.0/(R*T_up)
     pr=p_down/p_up
     pr_crit=(1+(k-1)/2)**(k/(1-k))
-    
-    if pr > pr_crit: 
+
+    if pr > pr_crit:
         # Mass flow rate if not choked [kg/s]
         mdot=A*p_up*1000.0/(R*T_up)**0.5*(2*k/(k-1.0)*pr**(2.0/k)*(1-pr**((k-1.0)/k)))**0.5
+    else:
+        # Mass flow rate if choked
+        mdot=A*rho_up*(k*R*T_up)**0.5*(1.+(k-1.)/2.)**((1+k)/(2*(1-k)))
+
+    # Default path returns mdot; the throat-state / speed-of-sound / Mach work below
+    # is only needed for the (rare) OUTPUT_VELOCITY / OUTPUT_MA requests, so skip it
+    # on the hot mdot path.
+    if other_output < 0:
+        return mdot
+
+    # Speed of sound
+    c=(k*R*T_up)**0.5
+    if pr > pr_crit:
         # Throat temperature [K]
         T_down=T_up*(p_down/p_up)**((k-1.0)/k)
         # Throat density [kg/m3]
@@ -643,17 +654,12 @@ cpdef double IsentropicNozzle(double A, State State_up, State State_down, int ot
         # Mach number
         Ma=v/c
     else:
-        # Mass flow rate if choked
-        mdot=A*rho_up*(k*R*T_up)**0.5*(1.+(k-1.)/2.)**((1+k)/(2*(1-k)))
         # Velocity at throat
         v=c
         # Mach Number
         Ma=1.0
-    
 
-    if other_output < 0:
-        return mdot
-    elif other_output == OUTPUT_VELOCITY:
+    if other_output == OUTPUT_VELOCITY:
         return v
     elif other_output == OUTPUT_MA:
         return Ma

--- a/PDSim/scroll/symm_scroll_geo.pyx
+++ b/PDSim/scroll/symm_scroll_geo.pyx
@@ -869,7 +869,7 @@ cpdef dict SA_forces(double theta, geoVals geo, bint poly = False, bint use_offs
     # Make sure you get the normal pointing towards the orbiting scroll!
     # The cross product of line going from inner to outer scroll wrap ends 
     # with normal should be negative
-    if np.cross([x1-x2,y1-y2,0],[nx1, ny1, 0])[2] > 0:
+    if (x1-x2)*ny1 - (y1-y2)*nx1 > 0:   # z-component of 2D cross product (scalar; avoids np.cross overhead)
         nx1 *= -1
         ny1 *= -1
 
@@ -880,8 +880,8 @@ cpdef dict SA_forces(double theta, geoVals geo, bint poly = False, bint use_offs
     fO_p_line = [A_line*nx1, A_line*ny1, 0.0]
     THETA = geo.phi_fie-theta-pi/2
     r_line = [xmid - geo.ro*cos(THETA), ymid - geo.ro*sin(THETA), 0.0]
-    cross = np.cross(r_line, fO_p_line)
-    M_O_p += cross[2]
+    # z-component of r_line x fO_p_line (scalar; avoids np.cross + normalize_axis_tuple overhead)
+    M_O_p += r_line[0]*fO_p_line[1] - r_line[1]*fO_p_line[0]
     
     exact_dict = dict(fx_p = fx_p,
                       fy_p = fy_p,


### PR DESCRIPTION
Two small, **bit-identical** hot-path optimizations found while profiling `examples/scroll_compressor.py`. No behaviour change — `scroll_compressor.py` mdot / volumetric efficiency / adiabatic efficiency are unchanged to **every printed digit** (mdot 55.175673362688805 g/s, vol-eff 91.95998551975654%, η 74.61003492585036%), verified before/after.

## Changes
1. **`symm_scroll_geo.SA_forces`** — replace two `np.cross([x,y,0],[a,b,0])[2]` calls with the scalar z-component `x*b - y*a`. Only the z-component is ever used, and `np.cross` pulls in `normalize_axis_tuple` + broadcasting machinery for what is a single multiply-subtract.
2. **`flow_models.IsentropicNozzle`** — the default call returns only `mdot`, but the throat temperature/density, speed of sound, velocity and Mach number were computed on *every* call. They're now computed lazily, behind the `OUTPUT_VELOCITY`/`OUTPUT_MA` guard. `mdot` is bit-unchanged.

## Impact
~**8%** faster on the full `scroll_compressor.py` solve (np.cross ~7%, nozzle ~1%), measured best-of-N. Both are pure overhead removal — exact same numerics.

## Context
These came out of a profiling exercise (native sampling) showing the scroll solve is dominated by PDSim's own Python/Cython framework + numpy (the EOS is only ~13–20% on modern CoolProp), so small-array-numpy and wasted-compute removals like these are free wins. Larger gains (Cythonizing the per-step callbacks, caching the per-θ geometry kernels) are noted as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)