### PR TITLE
Hoist invariant sum() out of calculate_force_terms inner loop (~16% faster)

### DIFF
--- a/PDSim/scroll/core.py
+++ b/PDSim/scroll/core.py
@@ -2496,6 +2496,10 @@ class Scroll(PDSimCore, _Scroll):
 
         fail_dict = {k: 0.0 for k in ['fx_p', 'fy_p', 'cx', 'cy', 'M_O_p']}
 
+        # _slice is invariant over the loops below, so hoist sum(_slice) out of the
+        # inner loop -- it was being recomputed (summing ~Itheta ints) on every
+        # (CV, theta) iteration, ~671k times, ~18% of the solve.  Bit-identical.
+        n_slice_sum = sum(_slice)
         for CVkey in self.CVs.keys:
             geo_components = []
             error_messages = []
@@ -2505,7 +2509,7 @@ class Scroll(PDSimCore, _Scroll):
                 except BaseException as BE:
                     error_messages.append(str(BE))
                     geo_components.append(fail_dict)
-                if len(error_messages) == sum(_slice):
+                if len(error_messages) == n_slice_sum:
                     print(set(error_messages))
                 
             if geo_components:


### PR DESCRIPTION
## Summary

`Scroll.calculate_force_terms` recomputed `sum(_slice)` on **every** iteration of its `for CVkey: for theta:` double loop, inside the condition `if len(error_messages) == sum(_slice)`. Since `_slice = list(range(self.Itheta+1))` is invariant across both loops, this summed ~`Itheta` integers **~671,000 times** per representative scroll run — about **18% of total solve time**.

This hoists it to a single `n_slice_sum = sum(_slice)` before the loops.

## Impact

- **~16% faster** end-to-end on `examples/scroll_compressor.py` (16.4s → 13.7s), interpreted/default build — no compilation, no API change.
- **Bit-identical** results: volumetric efficiency (91.95998551975654 %), adiabatic efficiency (74.61003492585036 %), mass flow (55.175673362688805 g/s), and the force/moment outputs all match to full precision before and after.

## How it was found

Native stack sampling of the unprofiled solve showed `builtins.sum` at ~18% of solve time; cProfile masks this because its per-call overhead inflates the millions of cheap delegation calls instead. cProfile's call graph (`print_callers`) then pinned the caller to `calculate_force_terms`.

## Note (not changed here)

The condition `len(error_messages) == sum(_slice)` looks like it may have been intended as `len(...) == len(_slice)` (i.e. "every force evaluation for this CV failed, so print the unique errors"). This PR preserves the existing behavior exactly and only removes the redundant recomputation; the suspected logic question is left for a separate decision.

## Test Plan

- [x] `examples/scroll_compressor.py` runs and all reported quantities are bit-identical to `master`
- [x] ~16% wall-clock reduction confirmed across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)